### PR TITLE
Fix #2: Run tests in Travis CI and add README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+language: node_js
+node_js:
+  - "6"
+addons:
+  chrome: stable
+before_script:
+  - npm start &
+  - sleep 30

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Enselic/sequencediagram.io.svg?branch=master)](https://travis-ci.org/Enselic/sequencediagram.io)
+
 https://sequencediagram.io
 ==========================
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "redux-undo": "^1.0.0-beta9-9-1"
   },
   "devDependencies": {
-    "chromedriver": "^2.30.1",
+    "chromedriver": "^2.31.0",
     "react-scripts": "1.0.7",
     "selenium-webdriver": "^3.4.0"
   },

--- a/src/end-to-end-test/index.test.js
+++ b/src/end-to-end-test/index.test.js
@@ -21,11 +21,11 @@ const SLOW_DOWN_FOR_HUMAN_OBSERVATION = 0
 // Default to headless testing when running in Continous Integration environments
 const HEADLESS = !!process.env.CI
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
 if (SLOW_DOWN_FOR_HUMAN_OBSERVATION) {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
-} else {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL *= 4;
 }
+
 let { Builder, By, until, Key, promise } = require('selenium-webdriver');
 let { Options } = require('selenium-webdriver/chrome');
 let devUtils = require('../devUtils');

--- a/src/end-to-end-test/misc.js
+++ b/src/end-to-end-test/misc.js
@@ -29,7 +29,7 @@ test('hints hide when clicking "Hide share info"', () => {
             waitForElement('Share by PNG'),
             waitForElement('Share by URL'),
             ]));
-})
+}, 20 * 1000)
 
 const tipText = 'Click "Add object" to start';
 

--- a/src/end-to-end-test/undo-redo.js
+++ b/src/end-to-end-test/undo-redo.js
@@ -100,4 +100,4 @@ test('use all features, then undo all, then redo all', async () => {
     asserter.assertFragmentAndPush('o1,Undoer;o2,Redoer;o3,User;m2,o3,o2,call(),a;m1,o3,o2,invoke(),r');
 
     return asserter.undoRedoAll();
-})
+}, 80 * 1000)


### PR DESCRIPTION
Bump to just released chromedriver 2.31.x so sendKeys work
with headless chrome. With 2.30.x it didn't work so the tests
could not run.

Also adjust timeouts since Travis CI runs tests a bit slower than
my laptop. Make use of test-specific timeouts.

Before running tests we need to
- start and wait for the dev server
- make sure --headless-supporting Chrome is present (requires Trusty)
- make sure Node version is modern (defaults to ancient)